### PR TITLE
[target-allocator] Add allocation strategy to distribute targets per node

### DIFF
--- a/apis/v1alpha1/allocation_strategy.go
+++ b/apis/v1alpha1/allocation_strategy.go
@@ -16,7 +16,7 @@ package v1alpha1
 
 type (
 	// OpenTelemetryTargetAllocatorAllocationStrategy represent which strategy to distribute target to each collector
-	// +kubebuilder:validation:Enum=least-weighted;consistent-hashing
+	// +kubebuilder:validation:Enum=least-weighted;consistent-hashing;per-node
 	OpenTelemetryTargetAllocatorAllocationStrategy string
 )
 
@@ -26,4 +26,7 @@ const (
 
 	// OpenTelemetryTargetAllocatorAllocationStrategyConsistentHashing targets will be consistently added to collectors, which allows a high-availability setup.
 	OpenTelemetryTargetAllocatorAllocationStrategyConsistentHashing OpenTelemetryTargetAllocatorAllocationStrategy = "consistent-hashing"
+
+	// OpenTelemetryTargetAllocatorAllocationStrategyPerNode targets will be assigned to the collector on the node they reside on (use only with daemon set).
+	OpenTelemetryTargetAllocatorAllocationStrategyPerNode OpenTelemetryTargetAllocatorAllocationStrategy = "per-node"
 )

--- a/apis/v1alpha1/opentelemetrycollector_types.go
+++ b/apis/v1alpha1/opentelemetrycollector_types.go
@@ -297,7 +297,7 @@ type OpenTelemetryTargetAllocator struct {
 	// +optional
 	Resources v1.ResourceRequirements `json:"resources,omitempty"`
 	// AllocationStrategy determines which strategy the target allocator should use for allocation.
-	// The current options are least-weighted and consistent-hashing. The default option is least-weighted
+	// The current options are least-weighted, consistent-hashing and per-node. The default option is least-weighted
 	// +optional
 	AllocationStrategy OpenTelemetryTargetAllocatorAllocationStrategy `json:"allocationStrategy,omitempty"`
 	// FilterStrategy determines how to filter targets before allocating them among the collectors.

--- a/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/bundle/manifests/opentelemetry.io_opentelemetrycollectors.yaml
@@ -4832,11 +4832,12 @@ spec:
                   allocationStrategy:
                     description: AllocationStrategy determines which strategy the
                       target allocator should use for allocation. The current options
-                      are least-weighted and consistent-hashing. The default option
+                      are least-weighted, consistent-hashing and per-node. The default option
                       is least-weighted
                     enum:
                     - least-weighted
                     - consistent-hashing
+                    - per-node
                     type: string
                   enabled:
                     description: Enabled indicates whether to use a target allocation

--- a/cmd/otel-allocator/allocation/allocatortest.go
+++ b/cmd/otel-allocator/allocation/allocatortest.go
@@ -52,6 +52,7 @@ func MakeNCollectors(n int, startingIndex int) map[string]*Collector {
 		toReturn[collector] = &Collector{
 			Name:       collector,
 			NumTargets: 0,
+			Node:       fmt.Sprintf("node-%d", i),
 		}
 	}
 	return toReturn

--- a/cmd/otel-allocator/allocation/consistent_hashing.go
+++ b/cmd/otel-allocator/allocation/consistent_hashing.go
@@ -161,7 +161,7 @@ func (c *consistentHashingAllocator) handleCollectors(diff diff.Changes[*Collect
 	}
 	// Insert the new collectors
 	for _, i := range diff.Additions() {
-		c.collectors[i.Name] = NewCollector(i.Name)
+		c.collectors[i.Name] = NewCollector(i.Name, i.Node)
 		c.consistentHasher.Add(c.collectors[i.Name])
 	}
 

--- a/cmd/otel-allocator/allocation/least_weighted.go
+++ b/cmd/otel-allocator/allocation/least_weighted.go
@@ -191,7 +191,7 @@ func (allocator *leastWeightedAllocator) handleCollectors(diff diff.Changes[*Col
 	}
 	// Insert the new collectors
 	for _, i := range diff.Additions() {
-		allocator.collectors[i.Name] = NewCollector(i.Name)
+		allocator.collectors[i.Name] = NewCollector(i.Name, i.Node)
 	}
 	if allocateTargets {
 		for _, item := range allocator.targetItems {

--- a/cmd/otel-allocator/allocation/per_node.go
+++ b/cmd/otel-allocator/allocation/per_node.go
@@ -1,0 +1,259 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocation
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/diff"
+	"github.com/open-telemetry/opentelemetry-operator/cmd/otel-allocator/target"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+)
+
+var _ Allocator = &perNodeAllocator{}
+
+const (
+	perNodeStrategyName = "per-node"
+
+	nodeNameLabel model.LabelName = "__meta_kubernetes_pod_node_name"
+)
+
+type perNodeAllocator struct {
+	// m protects collectors and targetItems for concurrent use.
+	m sync.RWMutex
+	// collectors is a map from a Collector's name to a Collector instance
+	collectors map[string]*Collector
+	// targetItems is a map from a target item's hash to the target items allocated state
+	targetItems map[string]*target.Item
+
+	// collectorKey -> job -> target item hash -> true
+	targetItemsPerJobPerCollector map[string]map[string]map[string]bool
+
+	log logr.Logger
+
+	filter Filter
+}
+
+func (allocator *perNodeAllocator) SetCollectors(collectors map[string]*Collector) {
+	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetCollectors", perNodeStrategyName))
+	defer timer.ObserveDuration()
+
+	CollectorsAllocatable.WithLabelValues(perNodeStrategyName).Set(float64(len(collectors)))
+	if len(collectors) == 0 {
+		allocator.log.Info("No collector instances present")
+		return
+	}
+
+	allocator.m.Lock()
+	defer allocator.m.Unlock()
+
+	// Check for collector changes
+	collectorsDiff := diff.Maps(allocator.collectors, collectors)
+	if len(collectorsDiff.Additions()) != 0 || len(collectorsDiff.Removals()) != 0 {
+		allocator.handleCollectors(collectorsDiff)
+	}
+}
+
+func (allocator *perNodeAllocator) handleCollectors(diff diff.Changes[*Collector]) {
+	// Clear removed collectors
+	for _, k := range diff.Removals() {
+		delete(allocator.collectors, k.Name)
+		delete(allocator.targetItemsPerJobPerCollector, k.Name)
+		TargetsPerCollector.WithLabelValues(k.Name, perNodeStrategyName).Set(0)
+	}
+
+	// Insert the new collectors
+	for _, i := range diff.Additions() {
+		allocator.collectors[i.Name] = NewCollector(i.Name, i.Node)
+	}
+}
+
+func (allocator *perNodeAllocator) SetTargets(targets map[string]*target.Item) {
+	timer := prometheus.NewTimer(TimeToAssign.WithLabelValues("SetTargets", perNodeStrategyName))
+	defer timer.ObserveDuration()
+
+	if allocator.filter != nil {
+		targets = allocator.filter.Apply(targets)
+	}
+	RecordTargetsKept(targets)
+
+	allocator.m.Lock()
+	defer allocator.m.Unlock()
+
+	if len(allocator.collectors) == 0 {
+		allocator.log.Info("No collector instances present, saving targets to allocate to collector(s)")
+		// If there were no targets discovered previously, assign this as the new set of target items
+		if len(allocator.targetItems) == 0 {
+			allocator.log.Info("Not discovered any targets previously, saving targets found to the targetItems set")
+			for k, item := range targets {
+				allocator.targetItems[k] = item
+			}
+		} else {
+			// If there were previously discovered targets, add or remove accordingly
+			targetsDiffEmptyCollectorSet := diff.Maps(allocator.targetItems, targets)
+
+			// Check for additions
+			if len(targetsDiffEmptyCollectorSet.Additions()) > 0 {
+				allocator.log.Info("New targets discovered, adding new targets to the targetItems set")
+				for k, item := range targetsDiffEmptyCollectorSet.Additions() {
+					// Do nothing if the item is already there
+					if _, ok := allocator.targetItems[k]; ok {
+						continue
+					} else {
+						// Add item to item pool
+						allocator.targetItems[k] = item
+					}
+				}
+			}
+
+			// Check for deletions
+			if len(targetsDiffEmptyCollectorSet.Removals()) > 0 {
+				allocator.log.Info("Targets removed, Removing targets from the targetItems set")
+				for k := range targetsDiffEmptyCollectorSet.Removals() {
+					// Delete item from target items
+					delete(allocator.targetItems, k)
+				}
+			}
+		}
+		return
+	}
+	// Check for target changes
+	targetsDiff := diff.Maps(allocator.targetItems, targets)
+	// If there are any additions or removals
+	if len(targetsDiff.Additions()) != 0 || len(targetsDiff.Removals()) != 0 {
+		allocator.handleTargets(targetsDiff)
+	}
+}
+func (allocator *perNodeAllocator) handleTargets(diff diff.Changes[*target.Item]) {
+	// Check for removals
+	for k, item := range allocator.targetItems {
+		// if the current item is in the removals list
+		if _, ok := diff.Removals()[k]; ok {
+			c := allocator.collectors[item.CollectorName]
+			c.NumTargets--
+			delete(allocator.targetItems, k)
+			delete(allocator.targetItemsPerJobPerCollector[item.CollectorName][item.JobName], item.Hash())
+			TargetsPerCollector.WithLabelValues(item.CollectorName, perNodeStrategyName).Set(float64(c.NumTargets))
+		}
+	}
+
+	// Check for additions
+	for k, item := range diff.Additions() {
+		// Do nothing if the item is already there
+		if _, ok := allocator.targetItems[k]; ok {
+			continue
+		} else {
+			// Add item to item pool and assign a collector
+			allocator.addTargetToTargetItems(item)
+		}
+	}
+}
+
+func (allocator *perNodeAllocator) addTargetToTargetItems(tg *target.Item) {
+	chosenCollector := allocator.findCollector(tg.Labels)
+	// TODO: How to handle this edge case? Can we have items without a collector?
+	if chosenCollector == nil {
+		allocator.log.V(2).Info("Couldn't find a collector for the target item", "item", tg, "collectors", allocator.collectors)
+		return
+	}
+	tg.CollectorName = chosenCollector.Name
+	allocator.targetItems[tg.Hash()] = tg
+	allocator.addCollectorTargetItemMapping(tg)
+	chosenCollector.NumTargets++
+	TargetsPerCollector.WithLabelValues(chosenCollector.Name, leastWeightedStrategyName).Set(float64(chosenCollector.NumTargets))
+}
+
+func (allocator *perNodeAllocator) findCollector(labels model.LabelSet) *Collector {
+	var col *Collector
+	for _, v := range allocator.collectors {
+		if nodeNameLabelValue, ok := labels[nodeNameLabel]; ok {
+			if v.Node == string(nodeNameLabelValue) {
+				col = v
+				break
+			}
+		}
+	}
+
+	return col
+}
+
+func (allocator *perNodeAllocator) addCollectorTargetItemMapping(tg *target.Item) {
+	if allocator.targetItemsPerJobPerCollector[tg.CollectorName] == nil {
+		allocator.targetItemsPerJobPerCollector[tg.CollectorName] = make(map[string]map[string]bool)
+	}
+	if allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] == nil {
+		allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName] = make(map[string]bool)
+	}
+	allocator.targetItemsPerJobPerCollector[tg.CollectorName][tg.JobName][tg.Hash()] = true
+}
+
+func (allocator *perNodeAllocator) TargetItems() map[string]*target.Item {
+	allocator.m.RLock()
+	defer allocator.m.RUnlock()
+	targetItemsCopy := make(map[string]*target.Item)
+	for k, v := range allocator.targetItems {
+		targetItemsCopy[k] = v
+	}
+	return targetItemsCopy
+}
+
+func (allocator *perNodeAllocator) Collectors() map[string]*Collector {
+	allocator.m.RLock()
+	defer allocator.m.RUnlock()
+	collectorsCopy := make(map[string]*Collector)
+	for k, v := range allocator.collectors {
+		collectorsCopy[k] = v
+	}
+	return collectorsCopy
+}
+
+func (allocator *perNodeAllocator) GetTargetsForCollectorAndJob(collector string, job string) []*target.Item {
+	allocator.m.RLock()
+	defer allocator.m.RUnlock()
+	if _, ok := allocator.targetItemsPerJobPerCollector[collector]; !ok {
+		return []*target.Item{}
+	}
+	if _, ok := allocator.targetItemsPerJobPerCollector[collector][job]; !ok {
+		return []*target.Item{}
+	}
+	targetItemsCopy := make([]*target.Item, len(allocator.targetItemsPerJobPerCollector[collector][job]))
+	index := 0
+	for targetHash := range allocator.targetItemsPerJobPerCollector[collector][job] {
+		targetItemsCopy[index] = allocator.targetItems[targetHash]
+		index++
+	}
+	return targetItemsCopy
+}
+
+func (allocator *perNodeAllocator) SetFilter(filter Filter) {
+	allocator.filter = filter
+}
+
+func newPerNodeAllocator(log logr.Logger, opts ...AllocationOption) Allocator {
+	pnAllocator := &perNodeAllocator{
+		log:                           log,
+		collectors:                    make(map[string]*Collector),
+		targetItems:                   make(map[string]*target.Item),
+		targetItemsPerJobPerCollector: make(map[string]map[string]map[string]bool),
+	}
+
+	for _, opt := range opts {
+		opt(pnAllocator)
+	}
+
+	return pnAllocator
+}

--- a/cmd/otel-allocator/allocation/per_node_test.go
+++ b/cmd/otel-allocator/allocation/per_node_test.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package allocation
+
+// TODO: Add tests

--- a/cmd/otel-allocator/allocation/strategy.go
+++ b/cmd/otel-allocator/allocation/strategy.go
@@ -106,6 +106,7 @@ var _ consistent.Member = Collector{}
 // This struct can be extended with information like annotations and labels in the future.
 type Collector struct {
 	Name       string
+	Node       string
 	NumTargets int
 }
 
@@ -117,8 +118,8 @@ func (c Collector) String() string {
 	return c.Name
 }
 
-func NewCollector(name string) *Collector {
-	return &Collector{Name: name}
+func NewCollector(name, node string) *Collector {
+	return &Collector{Name: name, Node: node}
 }
 
 func init() {
@@ -127,6 +128,10 @@ func init() {
 		panic(err)
 	}
 	err = Register(consistentHashingStrategyName, newConsistentHashingAllocator)
+	if err != nil {
+		panic(err)
+	}
+	err = Register(perNodeStrategyName, newPerNodeAllocator)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/otel-allocator/allocation/strategy_test.go
+++ b/cmd/otel-allocator/allocation/strategy_test.go
@@ -89,11 +89,11 @@ func Benchmark_Setting(b *testing.B) {
 }
 
 func TestCollectorDiff(t *testing.T) {
-	collector0 := NewCollector("collector-0")
-	collector1 := NewCollector("collector-1")
-	collector2 := NewCollector("collector-2")
-	collector3 := NewCollector("collector-3")
-	collector4 := NewCollector("collector-4")
+	collector0 := NewCollector("collector-0", "")
+	collector1 := NewCollector("collector-1", "")
+	collector2 := NewCollector("collector-2", "")
+	collector3 := NewCollector("collector-3", "")
+	collector4 := NewCollector("collector-4", "")
 	type args struct {
 		current map[string]*Collector
 		new     map[string]*Collector

--- a/cmd/otel-allocator/collector/collector.go
+++ b/cmd/otel-allocator/collector/collector.go
@@ -77,7 +77,7 @@ func (k *Client) Watch(ctx context.Context, labelMap map[string]string, fn func(
 	for i := range pods.Items {
 		pod := pods.Items[i]
 		if pod.GetObjectMeta().GetDeletionTimestamp() == nil {
-			collectorMap[pod.Name] = allocation.NewCollector(pod.Name)
+			collectorMap[pod.Name] = allocation.NewCollector(pod.Name, pod.Spec.NodeName)
 		}
 	}
 
@@ -130,7 +130,7 @@ func runWatch(ctx context.Context, k *Client, c <-chan watch.Event, collectorMap
 
 			switch event.Type { //nolint:exhaustive
 			case watch.Added:
-				collectorMap[pod.Name] = allocation.NewCollector(pod.Name)
+				collectorMap[pod.Name] = allocation.NewCollector(pod.Name, pod.Spec.NodeName)
 			case watch.Deleted:
 				delete(collectorMap, pod.Name)
 			}

--- a/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
+++ b/config/crd/bases/opentelemetry.io_opentelemetrycollectors.yaml
@@ -4829,11 +4829,12 @@ spec:
                   allocationStrategy:
                     description: AllocationStrategy determines which strategy the
                       target allocator should use for allocation. The current options
-                      are least-weighted and consistent-hashing. The default option
+                      are least-weighted, consistent-hashing and per-node. The default option
                       is least-weighted
                     enum:
                     - least-weighted
                     - consistent-hashing
+                    - per-node
                     type: string
                   enabled:
                     description: Enabled indicates whether to use a target allocation

--- a/docs/api.md
+++ b/docs/api.md
@@ -18020,9 +18020,9 @@ TargetAllocator indicates a value which determines whether to spawn a target all
         <td><b>allocationStrategy</b></td>
         <td>enum</td>
         <td>
-          AllocationStrategy determines which strategy the target allocator should use for allocation. The current options are least-weighted and consistent-hashing. The default option is least-weighted<br/>
+          AllocationStrategy determines which strategy the target allocator should use for allocation. The current options are least-weighted, consistent-hashing and per-node. The default option is least-weighted<br/>
           <br/>
-            <i>Enum</i>: least-weighted, consistent-hashing<br/>
+            <i>Enum</i>: least-weighted, consistent-hashing, per-node<br/>
         </td>
         <td>false</td>
       </tr><tr>


### PR DESCRIPTION
Relates to 
https://coralogix.atlassian.net/browse/ES-155.

Adds a new allocation strategy to target allocator, which will distribute targets to collectors on the basis of the node they belong to. This is intended to be run alongside collector in daemon set mode, i.e. agent.